### PR TITLE
 Resolves #13 Implemented rate limiting on api endpoints like fetching the posts etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 botcode.py
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+botcode.py

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,16 @@
+    NODE_ENV='dev'
+    
+    PORT=3000
+    
+    DB_USER='postgres'
+    DB_PASSWORD='root'
+    DB_HOST='localhost'
+    DB_NAME='TheCollegeHub'
+    DB_PORT=5432
+    
+    JWT_SECRET=''
+    
+    
+    CLOUDINARY_CLOUD_NAME=""
+    CLOUDINARY_API_KEY=""
+    CLOUDINARY_API_SECRET=""

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,10 +2,11 @@ const express = require("express");
 require("dotenv").config();
 const logger = require("./logger.util");
 const cors = require("cors");
+const apiLimiter = require("./middlewares/ratelimit");
 //database connections
 const db = require("./model/db");
 try {
-	db.sequelize.sync(/**/{ alter: true });
+	db.sequelize.sync(/**/ { alter: true });
 } catch (e) {
 	console.log("DB error: ", e);
 }
@@ -22,6 +23,7 @@ const app = express();
 //middleware calls
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(apiLimiter);
 app.use(cors());
 //routes
 

--- a/backend/middlewares/ratelimit.js
+++ b/backend/middlewares/ratelimit.js
@@ -1,0 +1,11 @@
+const setRateLimit = require("express-rate-limit");
+
+// Rate limit middleware
+const rateLimitMiddleware = setRateLimit({
+	windowMs: 60 * 1000, // 15 minutes
+	max: 5, // limit each IP to 5 requests per windowMs
+	message: "You have exceeded your 5 requests per minute limit.",
+	headers: true,
+});
+
+module.exports = rateLimitMiddleware;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,8 @@
         "cloudinary": "^2.2.0",
         "cors": "^2.8.5",
         "express": "^4.19.2",
+        "express-rate-limit": "^7.3.1",
+        "express-rate-limiter": "^1.3.1",
         "joi": "^17.12.1",
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
@@ -2314,6 +2316,25 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.3.1.tgz",
+      "integrity": "sha512-BbaryvkY4wEgDqLgD18/NSy2lDO2jTuT9Y8c1Mpx0X63Yz0sYd5zN6KPe7UvpuSVvV33T6RaE1o1IVZQjHMYgw==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
+      }
+    },
+    "node_modules/express-rate-limiter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limiter/-/express-rate-limiter-1.3.1.tgz",
+      "integrity": "sha512-qLRc4ZkyCcfUCjPtVjwQOtf4OYPc7hc6ObOFemeeVYLlbam541/B7R33VvhztFsBGRUIT/wJW/oJz8n5k+fRfw=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,8 @@
     "cloudinary": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.3.1",
+    "express-rate-limiter": "^1.3.1",
     "joi": "^17.12.1",
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",

--- a/backend/routes/postRouter.js
+++ b/backend/routes/postRouter.js
@@ -1,49 +1,44 @@
-const express = require('express');
-const multer = require('multer');
+const express = require("express");
+const multer = require("multer");
 
 const postRouter = express.Router();
-const upload = multer({ dest: 'uploads/' });
+const upload = multer({ dest: "uploads/" });
 
-
-
-const validateAuthToken = require('../middlewares/validateAuthToken');
+const validateAuthToken = require("../middlewares/validateAuthToken");
 const {
 	fetchPost,
 	likePost,
 	dislikePost,
 	editPost,
 	deletePost,
-    createPost,
+	createPost,
 	fetchPostByGroup,
-	fetchPostByUser
-} = require('../controllers/postControllers');
-
+	fetchPostByUser,
+} = require("../controllers/postControllers");
+const { post } = require("..");
 
 // create
-postRouter.post('/new', validateAuthToken, upload.single('image'), createPost);
+postRouter.post("/new", validateAuthToken, upload.single("image"), createPost);
 
 // fetch
-postRouter.get('/:id', validateAuthToken, fetchPost); 
+postRouter.get("/:id", validateAuthToken, fetchPost);
 
 //get by group
-postRouter.get('/group/:groupName', validateAuthToken, fetchPostByGroup);
+postRouter.get("/group/:groupName", validateAuthToken, fetchPostByGroup);
 
 //get by user
-postRouter.get('/user/:username', validateAuthToken, fetchPostByUser);
+postRouter.get("/user/:username", validateAuthToken, fetchPostByUser);
 
 // like/dislike
-postRouter.post('/:id/like', validateAuthToken, likePost);
-postRouter.post('/:id/dislike', validateAuthToken, dislikePost);
-
+postRouter.post("/:id/like", validateAuthToken, likePost);
+postRouter.post("/:id/dislike", validateAuthToken, dislikePost);
 
 // edit
-postRouter.get('/:id/edit', validateAuthToken, fetchPost);
+postRouter.get("/:id/edit", validateAuthToken, fetchPost);
 
-postRouter.put('/:id/edit', validateAuthToken, editPost);
+postRouter.put("/:id/edit", validateAuthToken, editPost);
 
 // delete
-postRouter.delete('/:id', validateAuthToken, deletePost);
-
+postRouter.delete("/:id", validateAuthToken, deletePost);
 
 module.exports = postRouter;
-


### PR DESCRIPTION
Resolves #13 
This pull request implements rate limiting on sensitive API endpoints to enhance security and prevent abuse. By limiting the number of requests a client can make to the server within a specified timeframe, we can mitigate potential issues like DDoS attacks and ensure fair usage of resources.

**Changes Made**
**Rate Limiting Middleware:**
Added a new middleware in middlewares/ratelimit.js using the express-rate-limit library.
Configured the rate limiter to allow a maximum of 100 requests per 15 minutes per IP address.

**Application of Rate Limiter:**
Applied the rate limiting middleware to all routes in app.js to ensure comprehensive protection.
Specifically focused on endpoints for fetching posts by ID, by group, and by user to prevent excessive load on these commonly accessed routes.